### PR TITLE
Add fonts  for FOP & iXBRL rendering and add endorsed xalan jar

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -24,19 +24,30 @@ COPY --chown=weblogic:weblogic config ${DOMAIN_NAME}/config/
 # Copy across chipsconfig directory
 COPY --chown=weblogic:weblogic chipsconfig ${DOMAIN_NAME}/chipsconfig/
 
-# Download libs from artifactory
+# Download libs and ixbrl fonts from artifactory
 RUN cd ${DOMAIN_NAME}/chipsconfig && \
     curl ${ARTIFACTORY_BASE_URL}/libs-release/antlr/antlr/2.7.6/antlr-2.7.6.jar -o antlr-2.7.6.jar && \
     curl ${ARTIFACTORY_BASE_URL}/libs-release/org/xhtmlrenderer/core-renderer/R5pre1patched/core-renderer-R5pre1patched.jar -o core-renderer.jar && \
     curl ${ARTIFACTORY_BASE_URL}/libs-release/log4j/log4j/1.2.14/log4j-1.2.14.jar -o log4j.jar && \
     curl ${ARTIFACTORY_BASE_URL}/local-ch-release/oracle/AQ/unknown/AQ-unknown.jar -o aqapi12.jar && \
     curl ${ARTIFACTORY_BASE_URL}/libs-release/com/lowagie/itext/2.0.8/itext-2.0.8.jar -o itext-2.0.8.jar && \
-    curl ${ARTIFACTORY_BASE_URL}/libs-release/com/staffware/ssoRMI/11.4.1/ssoRMI-11.4.1.jar -o ssoRMI.jar
+    curl ${ARTIFACTORY_BASE_URL}/libs-release/com/staffware/ssoRMI/11.4.1/ssoRMI-11.4.1.jar -o ssoRMI.jar && \
+    cd .. && \
+    curl ${ARTIFACTORY_BASE_URL}/local-ch-release/uk/gov/companieshouse/chips-ixbrl-fonts/1.0.0/chips-ixbrl-fonts-1.0.0.tar -o chips-ixbrl-fonts.tar && \
+    tar -xvf chips-ixbrl-fonts.tar && rm chips-ixbrl-fonts.tar
 
 # Set the credentials in the custom config.xml
 RUN $ORACLE_HOME/oracle_common/common/bin/wlst.sh -skipWLSModuleScanning container-scripts/set-credentials.py && \
     chmod 754 container-scripts/*.sh
 
+# Download fop fonts and endorsed libs from artifactory and install into JRE
+USER root
+RUN cd ${JAVA_HOME}/jre/lib && \
+    curl ${ARTIFACTORY_BASE_URL}/local-ch-release/uk/gov/companieshouse/chips-fop-fonts/1.0.0/chips-fop-fonts-1.0.0.tar -o chips-fop-fonts.tar && \
+    tar -xvf chips-fop-fonts.tar && rm chips-fop-fonts.tar && \
+    mkdir -p endorsed && cd endorsed && curl ${ARTIFACTORY_BASE_URL}/libs-release/xalan/xalan/2.7.0/xalan-2.7.0.jar -o xalan-2.7.0.jar
+
+USER weblogic
 CMD ["bash"]
 
 

--- a/README.md
+++ b/README.md
@@ -46,7 +46,6 @@ In order to use the image, a number of environment properties need to be defined
 docker-compose can be used to start all the required containers in one operation.
 
 It uses the docker-compose.yml file included in the repository to start up the following:
-- Apache container
 - WebLogic Administration server container
 - Four managed server/nodemanager containers
 
@@ -55,7 +54,7 @@ It uses the docker-compose.yml file included in the repository to start up the f
 The following steps should be taken before first starting the containers with docker-compose
 
 #### Environment variables
-In order to configure which version of the images to use when starting, there are two environment variables that can be set:
+In order to configure which version of the images to use when starting, there is an environment variable that can be set:
 |ENV VAR  | Description | Example| Default
 |--|--|--|--
 |CHIPS_DOMAIN_IMAGE  |The image repository and version to use for the chips-domain image  |12345678910.dkr.ecr.eu-west-2.amazonaws.com/chips-domain:1.0|chips-domain (latest local image)

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ To build the image, from the root of the repo run:
 **Important** The arg ADMIN_PASSWORD sets the administrator password that is used in the built image.  The password can easily be discovered simply by running `docker history chips-domain` Therefore, the password must be reset, along with other sensitive credentials when the image is actually used to start containers. That reset is handled automtically by the start scripts.
 
 ### Run time environment properties file
-In order to use the image, a number of environment properties need to be defined in a file, held locally to where the docker command is being run - for example, `cic.properties` 
+In order to use the image, a number of environment properties need to be defined in a file, held locally to where the docker command is being run - for example, `chips.properties` 
 |Property|Description  |Example
 |--|--|--
 |ADMIN_PASSWORD |The password to set for the weblogic user.  Needs to be at least 8 chars and include a number.|secret123

--- a/container-scripts/startAdmin.sh
+++ b/container-scripts/startAdmin.sh
@@ -20,10 +20,10 @@ echo "username=weblogic" > ${DOMAIN_HOME}/servers/${ADMIN_NAME}/security/boot.pr
 echo "password=${ADMIN_PASSWORD}" >> ${DOMAIN_HOME}/servers/${ADMIN_NAME}/security/boot.properties
 
 # Update the domain credentials to those provided by env var
-${ORACLE_HOME}/wlserver/common/bin/wlst.sh ${ORACLE_HOME}/container-scripts/set-credentials.py
+${ORACLE_HOME}/oracle_common/common/bin/wlst.sh -skipWLSModuleScanning ${ORACLE_HOME}/container-scripts/set-credentials.py
 
 # Set the jdbc connection strings and credentials
-${ORACLE_HOME}/wlserver/common/bin/wlst.sh ${ORACLE_HOME}/container-scripts/set-jdbc-details.py
+${ORACLE_HOME}/oracle_common/common/bin/wlst.sh -skipWLSModuleScanning ${ORACLE_HOME}/container-scripts/set-jdbc-details.py
 
 # Set the managed server startup arguments
 sed -i "s/@start-args@/${START_ARGS}/g" ${DOMAIN_HOME}/config/config.xml

--- a/container-scripts/startManagedServer.sh
+++ b/container-scripts/startManagedServer.sh
@@ -17,7 +17,7 @@ ${ORACLE_HOME}/wlserver/common/bin/wlst.sh ${ORACLE_HOME}/container-scripts/awai
 if [ $? -eq 0 ]; then
   echo "Admin server is running, so starting managed server"
 
-  ${ORACLE_HOME}/wlserver/common/bin/wlst.sh ${ORACLE_HOME}/container-scripts/start-managed-server.py
+  ${ORACLE_HOME}/oracle_common/common/bin/wlst.sh -skipWLSModuleScanning ${ORACLE_HOME}/container-scripts/start-managed-server.py
 else
 
   echo "Admin server is not running, or has not started within timeout"


### PR DESCRIPTION
We have identified some resources that aren’t yet present in the domain that will be needed for correct image generation in CHIPS:
(current live locations)
/apps/bea/fonts - used for ixbrl rendering
/apps/bea/jdk8/jre/lib/fonts  - used for FOP rendering
/apps/bea/jdk8/jre/lib/endorsed/xalan.jar - needed for correct operation under WL 12.2.1.4

Resolves: https://companieshouse.atlassian.net/browse/CM-743