### PR TITLE
Correct the name of the itext jar to fix accounts rendering issue

### DIFF
--- a/config/config.xml
+++ b/config/config.xml
@@ -110,7 +110,7 @@
     </web-server>
     <listen-address>wlserver1</listen-address>
     <server-start>
-      <class-path>/apps/oracle/chipsdomain:/apps/oracle/chipsdomain/chipsconfig/antlr-2.7.6.jar:/apps/oracle/chipsdomain/chipsconfig/log4j.jar:/apps/oracle/chipsdomain/chipsconfig/aqapi12.jar:/apps/oracle/chipsdomain/chipsconfig/aqbridge.jar:/apps/oracle/chipsdomain/chipsconfig/chips_config.jar:/apps/oracle/chipsdomain/chipsconfig/ssoRMI.jar:/apps/oracle/chipsdomain/chipsconfig/rmi_config.jar:/apps/oracle/chipsdomain/chipsconfig:/apps/oracle/chipsdomain/chipsconfig/xsl:/apps/oracle/chipsdomain/chipsconfig/rtfTemplates:/apps/oracle/chipsdomain/chipsconfig/core-renderer.jar:/apps/oracle/chipsdomain/chipsconfig/iText-2.0.8.jar:/apps/oracle/chipsconfig/chips-tuxedo-library-unversioned.jar</class-path>
+      <class-path>/apps/oracle/chipsdomain:/apps/oracle/chipsdomain/chipsconfig/antlr-2.7.6.jar:/apps/oracle/chipsdomain/chipsconfig/log4j.jar:/apps/oracle/chipsdomain/chipsconfig/aqapi12.jar:/apps/oracle/chipsdomain/chipsconfig/aqbridge.jar:/apps/oracle/chipsdomain/chipsconfig/chips_config.jar:/apps/oracle/chipsdomain/chipsconfig/ssoRMI.jar:/apps/oracle/chipsdomain/chipsconfig/rmi_config.jar:/apps/oracle/chipsdomain/chipsconfig:/apps/oracle/chipsdomain/chipsconfig/xsl:/apps/oracle/chipsdomain/chipsconfig/rtfTemplates:/apps/oracle/chipsdomain/chipsconfig/core-renderer.jar:/apps/oracle/chipsdomain/chipsconfig/itext-2.0.8.jar:/apps/oracle/chipsconfig/chips-tuxedo-library-unversioned.jar</class-path>
       <arguments>@start-args@</arguments>
     </server-start>
     <jta-migratable-target>
@@ -141,7 +141,7 @@
     </web-server>
     <listen-address>wlserver2</listen-address>
     <server-start>
-      <class-path>/apps/oracle/chipsdomain:/apps/oracle/chipsdomain/chipsconfig/antlr-2.7.6.jar:/apps/oracle/chipsdomain/chipsconfig/log4j.jar:/apps/oracle/chipsdomain/chipsconfig/aqapi12.jar:/apps/oracle/chipsdomain/chipsconfig/aqbridge.jar:/apps/oracle/chipsdomain/chipsconfig/chips_config.jar:/apps/oracle/chipsdomain/chipsconfig/ssoRMI.jar:/apps/oracle/chipsdomain/chipsconfig/rmi_config.jar:/apps/oracle/chipsdomain/chipsconfig:/apps/oracle/chipsdomain/chipsconfig/xsl:/apps/oracle/chipsdomain/chipsconfig/rtfTemplates:/apps/oracle/chipsdomain/chipsconfig/core-renderer.jar:/apps/oracle/chipsdomain/chipsconfig/iText-2.0.8.jar:/apps/oracle/chipsconfig/chips-tuxedo-library-unversioned.jar</class-path>
+      <class-path>/apps/oracle/chipsdomain:/apps/oracle/chipsdomain/chipsconfig/antlr-2.7.6.jar:/apps/oracle/chipsdomain/chipsconfig/log4j.jar:/apps/oracle/chipsdomain/chipsconfig/aqapi12.jar:/apps/oracle/chipsdomain/chipsconfig/aqbridge.jar:/apps/oracle/chipsdomain/chipsconfig/chips_config.jar:/apps/oracle/chipsdomain/chipsconfig/ssoRMI.jar:/apps/oracle/chipsdomain/chipsconfig/rmi_config.jar:/apps/oracle/chipsdomain/chipsconfig:/apps/oracle/chipsdomain/chipsconfig/xsl:/apps/oracle/chipsdomain/chipsconfig/rtfTemplates:/apps/oracle/chipsdomain/chipsconfig/core-renderer.jar:/apps/oracle/chipsdomain/chipsconfig/itext-2.0.8.jar:/apps/oracle/chipsconfig/chips-tuxedo-library-unversioned.jar</class-path>
       <arguments>@start-args@</arguments>
     </server-start>
     <jta-migratable-target>
@@ -172,7 +172,7 @@
     </web-server>
     <listen-address>wlserver3</listen-address>
     <server-start>
-      <class-path>/apps/oracle/chipsdomain:/apps/oracle/chipsdomain/chipsconfig/antlr-2.7.6.jar:/apps/oracle/chipsdomain/chipsconfig/log4j.jar:/apps/oracle/chipsdomain/chipsconfig/aqapi12.jar:/apps/oracle/chipsdomain/chipsconfig/aqbridge.jar:/apps/oracle/chipsdomain/chipsconfig/chips_config.jar:/apps/oracle/chipsdomain/chipsconfig/ssoRMI.jar:/apps/oracle/chipsdomain/chipsconfig/rmi_config.jar:/apps/oracle/chipsdomain/chipsconfig:/apps/oracle/chipsdomain/chipsconfig/xsl:/apps/oracle/chipsdomain/chipsconfig/rtfTemplates:/apps/oracle/chipsdomain/chipsconfig/core-renderer.jar:/apps/oracle/chipsdomain/chipsconfig/iText-2.0.8.jar:/apps/oracle/chipsconfig/chips-tuxedo-library-unversioned.jar</class-path>
+      <class-path>/apps/oracle/chipsdomain:/apps/oracle/chipsdomain/chipsconfig/antlr-2.7.6.jar:/apps/oracle/chipsdomain/chipsconfig/log4j.jar:/apps/oracle/chipsdomain/chipsconfig/aqapi12.jar:/apps/oracle/chipsdomain/chipsconfig/aqbridge.jar:/apps/oracle/chipsdomain/chipsconfig/chips_config.jar:/apps/oracle/chipsdomain/chipsconfig/ssoRMI.jar:/apps/oracle/chipsdomain/chipsconfig/rmi_config.jar:/apps/oracle/chipsdomain/chipsconfig:/apps/oracle/chipsdomain/chipsconfig/xsl:/apps/oracle/chipsdomain/chipsconfig/rtfTemplates:/apps/oracle/chipsdomain/chipsconfig/core-renderer.jar:/apps/oracle/chipsdomain/chipsconfig/itext-2.0.8.jar:/apps/oracle/chipsconfig/chips-tuxedo-library-unversioned.jar</class-path>
       <arguments>@start-args@</arguments>
     </server-start>
     <jta-migratable-target>
@@ -203,7 +203,7 @@
     </web-server>
     <listen-address>wlserver4</listen-address>
     <server-start>
-      <class-path>/apps/oracle/chipsdomain:/apps/oracle/chipsdomain/chipsconfig/antlr-2.7.6.jar:/apps/oracle/chipsdomain/chipsconfig/log4j.jar:/apps/oracle/chipsdomain/chipsconfig/aqapi12.jar:/apps/oracle/chipsdomain/chipsconfig/aqbridge.jar:/apps/oracle/chipsdomain/chipsconfig/chips_config.jar:/apps/oracle/chipsdomain/chipsconfig/ssoRMI.jar:/apps/oracle/chipsdomain/chipsconfig/rmi_config.jar:/apps/oracle/chipsdomain/chipsconfig:/apps/oracle/chipsdomain/chipsconfig/xsl:/apps/oracle/chipsdomain/chipsconfig/rtfTemplates:/apps/oracle/chipsdomain/chipsconfig/core-renderer.jar:/apps/oracle/chipsdomain/chipsconfig/iText-2.0.8.jar:/apps/oracle/chipsconfig/chips-tuxedo-library-unversioned.jar</class-path>
+      <class-path>/apps/oracle/chipsdomain:/apps/oracle/chipsdomain/chipsconfig/antlr-2.7.6.jar:/apps/oracle/chipsdomain/chipsconfig/log4j.jar:/apps/oracle/chipsdomain/chipsconfig/aqapi12.jar:/apps/oracle/chipsdomain/chipsconfig/aqbridge.jar:/apps/oracle/chipsdomain/chipsconfig/chips_config.jar:/apps/oracle/chipsdomain/chipsconfig/ssoRMI.jar:/apps/oracle/chipsdomain/chipsconfig/rmi_config.jar:/apps/oracle/chipsdomain/chipsconfig:/apps/oracle/chipsdomain/chipsconfig/xsl:/apps/oracle/chipsdomain/chipsconfig/rtfTemplates:/apps/oracle/chipsdomain/chipsconfig/core-renderer.jar:/apps/oracle/chipsdomain/chipsconfig/itext-2.0.8.jar:/apps/oracle/chipsconfig/chips-tuxedo-library-unversioned.jar</class-path>
       <arguments>@start-args@</arguments>
     </server-start>
     <jta-migratable-target>


### PR DESCRIPTION
Replace iText-2.0.8.jar with itext-2.0.8.jar to match the name of the actual file