### PR TITLE
Add classes to Admin server classpath to allow viewing of EfilingInput JMS messages

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -32,6 +32,8 @@ RUN cd ${DOMAIN_NAME}/chipsconfig && \
     curl ${ARTIFACTORY_BASE_URL}/local-ch-release/oracle/AQ/unknown/AQ-unknown.jar -o aqapi12.jar && \
     curl ${ARTIFACTORY_BASE_URL}/libs-release/com/lowagie/itext/2.0.8/itext-2.0.8.jar -o itext-2.0.8.jar && \
     curl ${ARTIFACTORY_BASE_URL}/libs-release/com/staffware/ssoRMI/11.4.1/ssoRMI-11.4.1.jar -o ssoRMI.jar && \
+    curl ${ARTIFACTORY_BASE_URL}/libs-release/org/jdom/jdom/1.1/jdom-1.1.jar -o jdom.jar && \
+    curl ${ARTIFACTORY_BASE_URL}/local-ch-release/chaps/jms/jmstool/0.0.2/jmstool-0.0.2.jar -o jmstool.jar && \
     curl ${ARTIFACTORY_BASE_URL}/libs-release/uk/gov/companieshouse/chips-tuxedo-library/1.0.0/chips-tuxedo-library-1.0.0.jar -o chips-tuxedo-library-1.0.0.jar && \
     cd .. && \
     curl ${ARTIFACTORY_BASE_URL}/local-ch-release/uk/gov/companieshouse/chips-ixbrl-fonts/1.0.0/chips-ixbrl-fonts-1.0.0.tar -o chips-ixbrl-fonts.tar && \

--- a/README.md
+++ b/README.md
@@ -41,6 +41,8 @@ In order to use the image, a number of environment properties need to be defined
 |AD_GROUP_BASE_DN|The base location under which groups can be found via a subtree search|OU=MySection, OU=MyOrg, DC=MyDepartment, DC=local
 |AUTO_START_NODES|A list of managed server names to auto start when the container is launched|wlserver1,wlserver2,wlserver3,wlserver4
 |TZ|The timezone to use when running WebLogic|Europe/London
+|T3_HOST_FQDN|The external hostname of the server to use when connecting via T3s protocol|127.0.0.1 or chips-ef-batch0.development.heritage.aws.internal
+|T3_HOST_PORT_PREFIX|The external port prefix of the servers to use when connecting via T3s protocol.  For example, if 2103 was set then wlserver1 would listen on 21031 and wlserver2 on 21032 etc. This must match up with the T3s ports exposed by docker and defined in docker-compose.yml|2103
 
 Optionally, there are a number of tuxedo related properties that can be defined in order to provide WebLogic Tuxedo Connector (WTC) services:
 |Property|Description  |Example

--- a/container-scripts/startAdmin.sh
+++ b/container-scripts/startAdmin.sh
@@ -43,4 +43,7 @@ ${ORACLE_HOME}/oracle_common/common/bin/wlst.sh -skipWLSModuleScanning ${ORACLE_
 # Prevent Derby from being started
 export DERBY_FLAG=false
 
+# Update the CLASSPATH of the Admin server to allow viewing of EF JMS messages
+export CLASSPATH=${CLASSPATH}:${DOMAIN_HOME}/chipsconfig/jmstool.jar:${DOMAIN_HOME}/chipsconfig/log4j.jar:${DOMAIN_HOME}/chipsconfig/jdom.jar
+
 ${DOMAIN_HOME}/bin/startWebLogic.sh $*


### PR DESCRIPTION
Adds some additional jars to support viewing of the EfilingInput messages within the WebLogic administration console.   Also adds a couple of unrelated environment variables to the README that were missed previously.

Resolves: https://companieshouse.atlassian.net/browse/CM-1365