### PR TITLE
Correct the default WebLogic server address

### DIFF
--- a/chipsconfig/ServersBean.properties.template
+++ b/chipsconfig/ServersBean.properties.template
@@ -27,7 +27,7 @@ template.supportTxSteps=false
 # JNDI properties
 #
 template.initialContextFactory=weblogic.jndi.WLInitialContextFactory
-template.providerUrl=t3://wladmin:7001
+template.providerUrl=t3://wlserver1:7001
 template.jmsFactory=uk.gov.ch.chips.jms.queue.CHQueueConnectionFactory
 template.weblogic.credentials=${ADMIN_PASSWORD}
 template.weblogic.principal=${WEBLOGIC_ADMIN_USERNAME}


### PR DESCRIPTION
Update the default WebLogic server address to be wlserver1 instead of wladmin, as that is where the swadmin utility will connect via when it is connecting to Staffware/iProcess.  Only the managed servers have the SSO daemons attached, which is required for this connection to work.

Resolves: https://companieshouse.atlassian.net/browse/CM-1420