### PR TITLE
Removed Network Visibilty Agent (NVA)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -80,6 +80,7 @@ RUN cd ${DOMAIN_NAME}/upload && \
 COPY --chown=weblogic:weblogic AppServerAgent-1.8-*.zip /opt/appdynamics/AppServerAgent.zip    
 RUN if [ -f /opt/appdynamics/AppServerAgent.zip ]; then \
       unzip /opt/appdynamics/AppServerAgent.zip -d /opt/appdynamics/AppServerAgent/  && \
+      rm -rf /opt/appdynamics/AppServerAgent/ver*/external-services/ && \
       rm /opt/appdynamics/AppServerAgent.zip; \
     fi
 


### PR DESCRIPTION
Removed AppDynamics NVA to avoid redundant error messages in agent logs. Done by removing NVA folder from agent directory.

Avoids log entries like:

ERROR NetVizAgentRequest - Fatal transport error...

CM-1058