### PR TITLE
Reference jmstool-0.0.6.jar to allow FES messages to be viewed

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -33,7 +33,7 @@ RUN cd ${DOMAIN_NAME}/chipsconfig && \
     curl ${ARTIFACTORY_BASE_URL}/libs-release/com/lowagie/itext/2.0.8/itext-2.0.8.jar -o itext-2.0.8.jar && \
     curl ${ARTIFACTORY_BASE_URL}/libs-release/com/staffware/ssoRMI/11.4.1/ssoRMI-11.4.1.jar -o ssoRMI.jar && \
     curl ${ARTIFACTORY_BASE_URL}/libs-release/org/jdom/jdom/1.1/jdom-1.1.jar -o jdom.jar && \
-    curl ${ARTIFACTORY_BASE_URL}/local-ch-release/chaps/jms/jmstool/0.0.2/jmstool-0.0.2.jar -o jmstool.jar && \
+    curl ${ARTIFACTORY_BASE_URL}/local-ch-release/chaps/jms/jmstool/0.0.6/jmstool-0.0.6.jar -o jmstool.jar && \
     curl ${ARTIFACTORY_BASE_URL}/libs-release/uk/gov/companieshouse/chips-tuxedo-library/1.0.0/chips-tuxedo-library-1.0.0.jar -o chips-tuxedo-library-1.0.0.jar && \
     curl ${ARTIFACTORY_BASE_URL}/libs-release/uk/gov/companieshouse/weblogic-tux-hostname-patch/1.0.0/weblogic-tux-hostname-patch-1.0.0.jar -o weblogic-tux-hostname-patch-1.0.0.jar && \
     cd .. && \


### PR DESCRIPTION
In order to view stuck FES (and other) JMS messages in the WebLogic console, the java classes the messages use must be present on the classpath.  This change references a new version of the jmstool lib that includes more classes to enable viewing of Response and FES messages.

Resolves:
https://companieshouse.atlassian.net/browse/CM-1548