### PR TITLE
Add SAML2 Single Sign On configuration

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -36,6 +36,7 @@ RUN cd ${DOMAIN_NAME}/chipsconfig && \
     curl ${ARTIFACTORY_BASE_URL}/local-ch-release/chaps/jms/jmstool/0.0.8/jmstool-0.0.8.jar -o jmstool.jar && \
     curl ${ARTIFACTORY_BASE_URL}/libs-release/uk/gov/companieshouse/chips-tuxedo-library/1.0.0/chips-tuxedo-library-1.0.0.jar -o chips-tuxedo-library-1.0.0.jar && \
     curl ${ARTIFACTORY_BASE_URL}/libs-release/uk/gov/companieshouse/weblogic-tux-hostname-patch/1.0.0/weblogic-tux-hostname-patch-1.0.0.jar -o weblogic-tux-hostname-patch-1.0.0.jar && \
+    curl ${ARTIFACTORY_BASE_URL}/libs-release/xalan/xalan/2.7.0/xalan-2.7.0.jar -o xalan.jar && \
     cd .. && \
     curl ${ARTIFACTORY_BASE_URL}/local-ch-release/uk/gov/companieshouse/chips-ixbrl-fonts/1.0.0/chips-ixbrl-fonts-1.0.0.tar -o chips-ixbrl-fonts.tar && \
     tar -xvf chips-ixbrl-fonts.tar && rm chips-ixbrl-fonts.tar

--- a/README.md
+++ b/README.md
@@ -59,10 +59,10 @@ Optionally, the domain can be initialised with additional internal realm users s
 |--|----|--
 |REALM_USER_N|Additional user to add to the realm.  This is mainly useful for adding users for the remote tuxedo domains, to allow for incoming calls.  This takes the form: `<unique name>=<username>\|<password>`.|REALM_USER_0=myusername\|mypassword
 
-The domain configuration supports SAML2 Single Sign On that can be configured by environment properties:
+The domain configuration supports SAML2 Single Sign On, that can also be configured by environment properties:
 |Property|Description  |Example
 |--|----|--
-|SSO_PUBLISHED_SITE_URL|The URL of the saml2 endpoint on Weblogic that the external IDP will redirect the user to after authentication.  Note that forward slashs need to be escaped.|https:\/\/chips-sso-test.companieshouse.gov.uk\/saml2
+|SSO_PUBLISHED_SITE_URL|The URL of the saml2 endpoint on Weblogic that the external IDP will redirect the user to after authentication.  Note that forward slashes need to be escaped.|https:\/\/chips-sso-test.companieshouse.gov.uk\/saml2
 |SSO_ENTITY_ID|A text identifier for the environment|sso-identity-chips-sso-test
 |SSO_CHIPS_DEFAULT_URL|The url that the user should be directed to if no redirect URL is provided from the IDP|https:\/\/chips-sso-test.companieshouse.gov.uk\/chips\/cff
 

--- a/README.md
+++ b/README.md
@@ -59,6 +59,14 @@ Optionally, the domain can be initialised with additional internal realm users s
 |--|----|--
 |REALM_USER_N|Additional user to add to the realm.  This is mainly useful for adding users for the remote tuxedo domains, to allow for incoming calls.  This takes the form: `<unique name>=<username>\|<password>`.|REALM_USER_0=myusername\|mypassword
 
+The domain configuration supports SAML2 Single Sign On that can be configured by environment properties:
+|Property|Description  |Example
+|--|----|--
+|SSO_PUBLISHED_SITE_URL|The URL of the saml2 endpoint on Weblogic that the external IDP will redirect the user to after authentication.  Note that forward slashs need to be escaped.|https:\/\/chips-sso-test.companieshouse.gov.uk\/saml2
+|SSO_ENTITY_ID|A text identifier for the environment|sso-identity-chips-sso-test
+|SSO_CHIPS_DEFAULT_URL|The url that the user should be directed to if no redirect URL is provided from the IDP|https:\/\/chips-sso-test.companieshouse.gov.uk\/chips\/cff
+
+
 
 ## docker-compose
 docker-compose can be used to start all the required containers in one operation.

--- a/config/config.xml
+++ b/config/config.xml
@@ -433,7 +433,7 @@
     <target>wlcluster</target>
     <module-type>ear</module-type>
     <source-path>upload/weblogic/chips.ear</source-path>
-    <security-dd-model>DDOnly</security-dd-model>
+    <security-dd-model>CustomRolesAndPolicies</security-dd-model>
     <staging-mode>nostage</staging-mode>
     <plan-staging-mode xsi:nil="true"></plan-staging-mode>
     <cache-in-app-directory>false</cache-in-app-directory>

--- a/config/config.xml
+++ b/config/config.xml
@@ -34,6 +34,13 @@
         <wls:static-group-dns-from-member-dn-filter>(&amp;(member=%M)(objectclass=group))</wls:static-group-dns-from-member-dn-filter>
         <wls:group-membership-searching>off</wls:group-membership-searching>
       </sec:authentication-provider>
+      <sec:authentication-provider xmlns:sam="http://xmlns.oracle.com/weblogic/security/saml2" xsi:type="sam:saml2-identity-asserterType">
+        <sec:name>SAML_IA</sec:name>
+      </sec:authentication-provider>
+      <sec:authentication-provider xsi:type="wls:saml-authenticatorType">
+        <sec:name>SAML_AUTH</sec:name>
+        <sec:control-flag>OPTIONAL</sec:control-flag>
+      </sec:authentication-provider>
       <sec:role-mapper xmlns:xac="http://xmlns.oracle.com/weblogic/security/xacml" xsi:type="xac:xacml-role-mapperType">
         <sec:name>XACMLRoleMapper</sec:name>
       </sec:role-mapper>
@@ -162,6 +169,34 @@
       <cluster>wlcluster</cluster>
     </jta-migratable-target>
     <weblogic-plugin-enabled>true</weblogic-plugin-enabled>
+    <single-sign-on-services>
+      <published-site-url>@published-site-url@/saml2</published-site-url>
+      <entity-id>azure-sso-saml2-wlserver1</entity-id>
+      <service-provider-enabled>true</service-provider-enabled>
+      <default-url>@chips-default-url@/chips/cff</default-url>
+      <service-provider-artifact-binding-enabled>true</service-provider-artifact-binding-enabled>
+      <service-provider-post-binding-enabled>true</service-provider-post-binding-enabled>
+      <service-provider-preferred-binding>HTTP/POST</service-provider-preferred-binding>
+      <sign-authn-requests>false</sign-authn-requests>
+      <want-assertions-signed>false</want-assertions-signed>
+      <force-authn>false</force-authn>
+      <passive>false</passive>
+      <recipient-check-enabled>true</recipient-check-enabled>
+      <post-one-use-check-enabled>true</post-one-use-check-enabled>
+      <want-transport-layer-security-client-authentication>false</want-transport-layer-security-client-authentication>
+      <want-basic-auth-client-authentication>false</want-basic-auth-client-authentication>
+      <authn-request-max-cache-size>10000</authn-request-max-cache-size>
+      <authn-request-timeout>300</authn-request-timeout>
+      <replicated-cache-enabled>false</replicated-cache-enabled>
+      <metadata-encryption-algorithm>aes128-gcm</metadata-encryption-algorithm>
+      <metadata-encryption-algorithm>aes192-gcm</metadata-encryption-algorithm>
+      <metadata-encryption-algorithm>aes256-gcm</metadata-encryption-algorithm>
+      <metadata-encryption-algorithm>aes128-cbc</metadata-encryption-algorithm>
+      <metadata-encryption-algorithm>aes192-cbc</metadata-encryption-algorithm>
+      <metadata-encryption-algorithm>aes256-cbc</metadata-encryption-algorithm>
+      <metadata-encryption-algorithm>rsa-oaep</metadata-encryption-algorithm>
+      <metadata-encryption-algorithm>rsa-oaep-mgf1p</metadata-encryption-algorithm>
+    </single-sign-on-services>
   </server>
   <server>
     <name>wlserver2</name>
@@ -207,6 +242,34 @@
       <cluster>wlcluster</cluster>
     </jta-migratable-target>
     <weblogic-plugin-enabled>true</weblogic-plugin-enabled>
+    <single-sign-on-services>
+      <published-site-url>@published-site-url@/saml2</published-site-url>
+      <entity-id>azure-sso-saml2-wlserver2</entity-id>
+      <service-provider-enabled>true</service-provider-enabled>
+      <default-url>@chips-default-url@/chips/cff</default-url>
+      <service-provider-artifact-binding-enabled>true</service-provider-artifact-binding-enabled>
+      <service-provider-post-binding-enabled>true</service-provider-post-binding-enabled>
+      <service-provider-preferred-binding>HTTP/POST</service-provider-preferred-binding>
+      <sign-authn-requests>false</sign-authn-requests>
+      <want-assertions-signed>false</want-assertions-signed>
+      <force-authn>false</force-authn>
+      <passive>false</passive>
+      <recipient-check-enabled>true</recipient-check-enabled>
+      <post-one-use-check-enabled>true</post-one-use-check-enabled>
+      <want-transport-layer-security-client-authentication>false</want-transport-layer-security-client-authentication>
+      <want-basic-auth-client-authentication>false</want-basic-auth-client-authentication>
+      <authn-request-max-cache-size>10000</authn-request-max-cache-size>
+      <authn-request-timeout>300</authn-request-timeout>
+      <replicated-cache-enabled>false</replicated-cache-enabled>
+      <metadata-encryption-algorithm>aes128-gcm</metadata-encryption-algorithm>
+      <metadata-encryption-algorithm>aes192-gcm</metadata-encryption-algorithm>
+      <metadata-encryption-algorithm>aes256-gcm</metadata-encryption-algorithm>
+      <metadata-encryption-algorithm>aes128-cbc</metadata-encryption-algorithm>
+      <metadata-encryption-algorithm>aes192-cbc</metadata-encryption-algorithm>
+      <metadata-encryption-algorithm>aes256-cbc</metadata-encryption-algorithm>
+      <metadata-encryption-algorithm>rsa-oaep</metadata-encryption-algorithm>
+      <metadata-encryption-algorithm>rsa-oaep-mgf1p</metadata-encryption-algorithm>
+    </single-sign-on-services>
   </server>
   <server>
     <name>wlserver3</name>
@@ -252,6 +315,34 @@
       <cluster>wlcluster</cluster>
     </jta-migratable-target>
     <weblogic-plugin-enabled>true</weblogic-plugin-enabled>
+    <single-sign-on-services>
+      <published-site-url>@published-site-url@/saml2</published-site-url>
+      <entity-id>azure-sso-saml2-wlserver3</entity-id>
+      <service-provider-enabled>true</service-provider-enabled>
+      <default-url>@chips-default-url@/chips/cff</default-url>
+      <service-provider-artifact-binding-enabled>true</service-provider-artifact-binding-enabled>
+      <service-provider-post-binding-enabled>true</service-provider-post-binding-enabled>
+      <service-provider-preferred-binding>HTTP/POST</service-provider-preferred-binding>
+      <sign-authn-requests>false</sign-authn-requests>
+      <want-assertions-signed>false</want-assertions-signed>
+      <force-authn>false</force-authn>
+      <passive>false</passive>
+      <recipient-check-enabled>true</recipient-check-enabled>
+      <post-one-use-check-enabled>true</post-one-use-check-enabled>
+      <want-transport-layer-security-client-authentication>false</want-transport-layer-security-client-authentication>
+      <want-basic-auth-client-authentication>false</want-basic-auth-client-authentication>
+      <authn-request-max-cache-size>10000</authn-request-max-cache-size>
+      <authn-request-timeout>300</authn-request-timeout>
+      <replicated-cache-enabled>false</replicated-cache-enabled>
+      <metadata-encryption-algorithm>aes128-gcm</metadata-encryption-algorithm>
+      <metadata-encryption-algorithm>aes192-gcm</metadata-encryption-algorithm>
+      <metadata-encryption-algorithm>aes256-gcm</metadata-encryption-algorithm>
+      <metadata-encryption-algorithm>aes128-cbc</metadata-encryption-algorithm>
+      <metadata-encryption-algorithm>aes192-cbc</metadata-encryption-algorithm>
+      <metadata-encryption-algorithm>aes256-cbc</metadata-encryption-algorithm>
+      <metadata-encryption-algorithm>rsa-oaep</metadata-encryption-algorithm>
+      <metadata-encryption-algorithm>rsa-oaep-mgf1p</metadata-encryption-algorithm>
+    </single-sign-on-services>
   </server>
   <server>
     <name>wlserver4</name>
@@ -297,6 +388,34 @@
       <cluster>wlcluster</cluster>
     </jta-migratable-target>
     <weblogic-plugin-enabled>true</weblogic-plugin-enabled>
+    <single-sign-on-services>
+      <published-site-url>@published-site-url@/saml2</published-site-url>
+      <entity-id>azure-sso-saml2-wlserver4</entity-id>
+      <service-provider-enabled>true</service-provider-enabled>
+      <default-url>@chips-default-url@/chips/cff</default-url>
+      <service-provider-artifact-binding-enabled>true</service-provider-artifact-binding-enabled>
+      <service-provider-post-binding-enabled>true</service-provider-post-binding-enabled>
+      <service-provider-preferred-binding>HTTP/POST</service-provider-preferred-binding>
+      <sign-authn-requests>false</sign-authn-requests>
+      <want-assertions-signed>false</want-assertions-signed>
+      <force-authn>false</force-authn>
+      <passive>false</passive>
+      <recipient-check-enabled>true</recipient-check-enabled>
+      <post-one-use-check-enabled>true</post-one-use-check-enabled>
+      <want-transport-layer-security-client-authentication>false</want-transport-layer-security-client-authentication>
+      <want-basic-auth-client-authentication>false</want-basic-auth-client-authentication>
+      <authn-request-max-cache-size>10000</authn-request-max-cache-size>
+      <authn-request-timeout>300</authn-request-timeout>
+      <replicated-cache-enabled>false</replicated-cache-enabled>
+      <metadata-encryption-algorithm>aes128-gcm</metadata-encryption-algorithm>
+      <metadata-encryption-algorithm>aes192-gcm</metadata-encryption-algorithm>
+      <metadata-encryption-algorithm>aes256-gcm</metadata-encryption-algorithm>
+      <metadata-encryption-algorithm>aes128-cbc</metadata-encryption-algorithm>
+      <metadata-encryption-algorithm>aes192-cbc</metadata-encryption-algorithm>
+      <metadata-encryption-algorithm>aes256-cbc</metadata-encryption-algorithm>
+      <metadata-encryption-algorithm>rsa-oaep</metadata-encryption-algorithm>
+      <metadata-encryption-algorithm>rsa-oaep-mgf1p</metadata-encryption-algorithm>
+    </single-sign-on-services>
   </server>
   <cluster>
     <name>wlcluster</name>

--- a/config/config.xml
+++ b/config/config.xml
@@ -161,7 +161,7 @@
       <client-certificate-enforced>false</client-certificate-enforced>
     </network-access-point>
     <server-start>
-      <class-path>/apps/oracle/chipsdomain:/apps/oracle/chipsdomain/chipsconfig/antlr-2.7.6.jar:/apps/oracle/chipsdomain/chipsconfig/log4j.jar:/apps/oracle/chipsdomain/chipsconfig/aqapi12.jar:/apps/oracle/chipsdomain/chipsconfig/aqbridge.jar:/apps/oracle/chipsdomain/chipsconfig/chips_config.jar:/apps/oracle/chipsdomain/chipsconfig/ssoRMI.jar:/apps/oracle/chipsdomain/chipsconfig/rmi_config.jar:/apps/oracle/chipsdomain/chipsconfig:/apps/oracle/chipsdomain/chipsconfig/xsl:/apps/oracle/chipsdomain/chipsconfig/rtfTemplates:/apps/oracle/chipsdomain/chipsconfig/core-renderer.jar:/apps/oracle/chipsdomain/chipsconfig/itext-2.0.8.jar:/apps/oracle/chipsdomain/chipsconfig/chips-tuxedo-library-1.0.0.jar</class-path>
+      <class-path>/apps/oracle/chipsdomain:/apps/oracle/chipsdomain/chipsconfig/xalan.jar:/apps/oracle/chipsdomain/chipsconfig/antlr-2.7.6.jar:/apps/oracle/chipsdomain/chipsconfig/log4j.jar:/apps/oracle/chipsdomain/chipsconfig/aqapi12.jar:/apps/oracle/chipsdomain/chipsconfig/aqbridge.jar:/apps/oracle/chipsdomain/chipsconfig/chips_config.jar:/apps/oracle/chipsdomain/chipsconfig/ssoRMI.jar:/apps/oracle/chipsdomain/chipsconfig/rmi_config.jar:/apps/oracle/chipsdomain/chipsconfig:/apps/oracle/chipsdomain/chipsconfig/xsl:/apps/oracle/chipsdomain/chipsconfig/rtfTemplates:/apps/oracle/chipsdomain/chipsconfig/core-renderer.jar:/apps/oracle/chipsdomain/chipsconfig/itext-2.0.8.jar:/apps/oracle/chipsdomain/chipsconfig/chips-tuxedo-library-1.0.0.jar</class-path>
       <arguments>@start-args@</arguments>
     </server-start>
     <jta-migratable-target>
@@ -234,7 +234,7 @@
       <client-certificate-enforced>false</client-certificate-enforced>
     </network-access-point>
     <server-start>
-      <class-path>/apps/oracle/chipsdomain:/apps/oracle/chipsdomain/chipsconfig/antlr-2.7.6.jar:/apps/oracle/chipsdomain/chipsconfig/log4j.jar:/apps/oracle/chipsdomain/chipsconfig/aqapi12.jar:/apps/oracle/chipsdomain/chipsconfig/aqbridge.jar:/apps/oracle/chipsdomain/chipsconfig/chips_config.jar:/apps/oracle/chipsdomain/chipsconfig/ssoRMI.jar:/apps/oracle/chipsdomain/chipsconfig/rmi_config.jar:/apps/oracle/chipsdomain/chipsconfig:/apps/oracle/chipsdomain/chipsconfig/xsl:/apps/oracle/chipsdomain/chipsconfig/rtfTemplates:/apps/oracle/chipsdomain/chipsconfig/core-renderer.jar:/apps/oracle/chipsdomain/chipsconfig/itext-2.0.8.jar:/apps/oracle/chipsdomain/chipsconfig/chips-tuxedo-library-1.0.0.jar</class-path>
+      <class-path>/apps/oracle/chipsdomain:/apps/oracle/chipsdomain/chipsconfig/xalan.jar:/apps/oracle/chipsdomain/chipsconfig/antlr-2.7.6.jar:/apps/oracle/chipsdomain/chipsconfig/log4j.jar:/apps/oracle/chipsdomain/chipsconfig/aqapi12.jar:/apps/oracle/chipsdomain/chipsconfig/aqbridge.jar:/apps/oracle/chipsdomain/chipsconfig/chips_config.jar:/apps/oracle/chipsdomain/chipsconfig/ssoRMI.jar:/apps/oracle/chipsdomain/chipsconfig/rmi_config.jar:/apps/oracle/chipsdomain/chipsconfig:/apps/oracle/chipsdomain/chipsconfig/xsl:/apps/oracle/chipsdomain/chipsconfig/rtfTemplates:/apps/oracle/chipsdomain/chipsconfig/core-renderer.jar:/apps/oracle/chipsdomain/chipsconfig/itext-2.0.8.jar:/apps/oracle/chipsdomain/chipsconfig/chips-tuxedo-library-1.0.0.jar</class-path>
       <arguments>@start-args@</arguments>
     </server-start>
     <jta-migratable-target>
@@ -307,7 +307,7 @@
       <client-certificate-enforced>false</client-certificate-enforced>
     </network-access-point>
     <server-start>
-      <class-path>/apps/oracle/chipsdomain:/apps/oracle/chipsdomain/chipsconfig/antlr-2.7.6.jar:/apps/oracle/chipsdomain/chipsconfig/log4j.jar:/apps/oracle/chipsdomain/chipsconfig/aqapi12.jar:/apps/oracle/chipsdomain/chipsconfig/aqbridge.jar:/apps/oracle/chipsdomain/chipsconfig/chips_config.jar:/apps/oracle/chipsdomain/chipsconfig/ssoRMI.jar:/apps/oracle/chipsdomain/chipsconfig/rmi_config.jar:/apps/oracle/chipsdomain/chipsconfig:/apps/oracle/chipsdomain/chipsconfig/xsl:/apps/oracle/chipsdomain/chipsconfig/rtfTemplates:/apps/oracle/chipsdomain/chipsconfig/core-renderer.jar:/apps/oracle/chipsdomain/chipsconfig/itext-2.0.8.jar:/apps/oracle/chipsdomain/chipsconfig/chips-tuxedo-library-1.0.0.jar</class-path>
+      <class-path>/apps/oracle/chipsdomain:/apps/oracle/chipsdomain/chipsconfig/xalan.jar:/apps/oracle/chipsdomain/chipsconfig/antlr-2.7.6.jar:/apps/oracle/chipsdomain/chipsconfig/log4j.jar:/apps/oracle/chipsdomain/chipsconfig/aqapi12.jar:/apps/oracle/chipsdomain/chipsconfig/aqbridge.jar:/apps/oracle/chipsdomain/chipsconfig/chips_config.jar:/apps/oracle/chipsdomain/chipsconfig/ssoRMI.jar:/apps/oracle/chipsdomain/chipsconfig/rmi_config.jar:/apps/oracle/chipsdomain/chipsconfig:/apps/oracle/chipsdomain/chipsconfig/xsl:/apps/oracle/chipsdomain/chipsconfig/rtfTemplates:/apps/oracle/chipsdomain/chipsconfig/core-renderer.jar:/apps/oracle/chipsdomain/chipsconfig/itext-2.0.8.jar:/apps/oracle/chipsdomain/chipsconfig/chips-tuxedo-library-1.0.0.jar</class-path>
       <arguments>@start-args@</arguments>
     </server-start>
     <jta-migratable-target>
@@ -380,7 +380,7 @@
       <client-certificate-enforced>false</client-certificate-enforced>
     </network-access-point>
     <server-start>
-      <class-path>/apps/oracle/chipsdomain:/apps/oracle/chipsdomain/chipsconfig/antlr-2.7.6.jar:/apps/oracle/chipsdomain/chipsconfig/log4j.jar:/apps/oracle/chipsdomain/chipsconfig/aqapi12.jar:/apps/oracle/chipsdomain/chipsconfig/aqbridge.jar:/apps/oracle/chipsdomain/chipsconfig/chips_config.jar:/apps/oracle/chipsdomain/chipsconfig/ssoRMI.jar:/apps/oracle/chipsdomain/chipsconfig/rmi_config.jar:/apps/oracle/chipsdomain/chipsconfig:/apps/oracle/chipsdomain/chipsconfig/xsl:/apps/oracle/chipsdomain/chipsconfig/rtfTemplates:/apps/oracle/chipsdomain/chipsconfig/core-renderer.jar:/apps/oracle/chipsdomain/chipsconfig/itext-2.0.8.jar:/apps/oracle/chipsdomain/chipsconfig/chips-tuxedo-library-1.0.0.jar</class-path>
+      <class-path>/apps/oracle/chipsdomain:/apps/oracle/chipsdomain/chipsconfig/xalan.jar:/apps/oracle/chipsdomain/chipsconfig/antlr-2.7.6.jar:/apps/oracle/chipsdomain/chipsconfig/log4j.jar:/apps/oracle/chipsdomain/chipsconfig/aqapi12.jar:/apps/oracle/chipsdomain/chipsconfig/aqbridge.jar:/apps/oracle/chipsdomain/chipsconfig/chips_config.jar:/apps/oracle/chipsdomain/chipsconfig/ssoRMI.jar:/apps/oracle/chipsdomain/chipsconfig/rmi_config.jar:/apps/oracle/chipsdomain/chipsconfig:/apps/oracle/chipsdomain/chipsconfig/xsl:/apps/oracle/chipsdomain/chipsconfig/rtfTemplates:/apps/oracle/chipsdomain/chipsconfig/core-renderer.jar:/apps/oracle/chipsdomain/chipsconfig/itext-2.0.8.jar:/apps/oracle/chipsdomain/chipsconfig/chips-tuxedo-library-1.0.0.jar</class-path>
       <arguments>@start-args@</arguments>
     </server-start>
     <jta-migratable-target>

--- a/config/config.xml
+++ b/config/config.xml
@@ -5,6 +5,10 @@
   <security-configuration>
     <name>chipsdomain</name>
     <realm>
+      <sec:authentication-provider xsi:type="wls:saml-authenticatorType">
+        <sec:name>SAML_AUTH</sec:name>
+        <sec:control-flag>SUFFICIENT</sec:control-flag>
+      </sec:authentication-provider>
       <sec:authentication-provider xsi:type="wls:default-authenticatorType">
         <sec:name>DefaultAuthenticator</sec:name>
         <sec:control-flag>SUFFICIENT</sec:control-flag>
@@ -15,7 +19,7 @@
       </sec:authentication-provider>
       <sec:authentication-provider xsi:type="wls:active-directory-authenticatorType">
         <sec:name>AD_LDAP</sec:name>
-        <sec:control-flag>REQUIRED</sec:control-flag>
+        <sec:control-flag>OPTIONAL</sec:control-flag>
         <wls:host></wls:host>
         <wls:port></wls:port>
         <wls:ssl-enabled>true</wls:ssl-enabled>
@@ -36,10 +40,6 @@
       </sec:authentication-provider>
       <sec:authentication-provider xmlns:sam="http://xmlns.oracle.com/weblogic/security/saml2" xsi:type="sam:saml2-identity-asserterType">
         <sec:name>SAML_IA</sec:name>
-      </sec:authentication-provider>
-      <sec:authentication-provider xsi:type="wls:saml-authenticatorType">
-        <sec:name>SAML_AUTH</sec:name>
-        <sec:control-flag>OPTIONAL</sec:control-flag>
       </sec:authentication-provider>
       <sec:role-mapper xmlns:xac="http://xmlns.oracle.com/weblogic/security/xacml" xsi:type="xac:xacml-role-mapperType">
         <sec:name>XACMLRoleMapper</sec:name>
@@ -170,10 +170,10 @@
     </jta-migratable-target>
     <weblogic-plugin-enabled>true</weblogic-plugin-enabled>
     <single-sign-on-services>
-      <published-site-url>@published-site-url@/saml2</published-site-url>
-      <entity-id>azure-sso-saml2-wlserver1</entity-id>
+      <published-site-url>@sso-published-site-url@</published-site-url>
+      <entity-id>@sso-entity-id@</entity-id>
       <service-provider-enabled>true</service-provider-enabled>
-      <default-url>@chips-default-url@/chips/cff</default-url>
+      <default-url>@sso-chips-default-url@</default-url>
       <service-provider-artifact-binding-enabled>true</service-provider-artifact-binding-enabled>
       <service-provider-post-binding-enabled>true</service-provider-post-binding-enabled>
       <service-provider-preferred-binding>HTTP/POST</service-provider-preferred-binding>
@@ -243,10 +243,10 @@
     </jta-migratable-target>
     <weblogic-plugin-enabled>true</weblogic-plugin-enabled>
     <single-sign-on-services>
-      <published-site-url>@published-site-url@/saml2</published-site-url>
-      <entity-id>azure-sso-saml2-wlserver2</entity-id>
+      <published-site-url>@sso-published-site-url@</published-site-url>
+      <entity-id>@sso-entity-id@</entity-id>
       <service-provider-enabled>true</service-provider-enabled>
-      <default-url>@chips-default-url@/chips/cff</default-url>
+      <default-url>@sso-chips-default-url@</default-url>
       <service-provider-artifact-binding-enabled>true</service-provider-artifact-binding-enabled>
       <service-provider-post-binding-enabled>true</service-provider-post-binding-enabled>
       <service-provider-preferred-binding>HTTP/POST</service-provider-preferred-binding>
@@ -316,10 +316,10 @@
     </jta-migratable-target>
     <weblogic-plugin-enabled>true</weblogic-plugin-enabled>
     <single-sign-on-services>
-      <published-site-url>@published-site-url@/saml2</published-site-url>
-      <entity-id>azure-sso-saml2-wlserver3</entity-id>
+      <published-site-url>@sso-published-site-url@</published-site-url>
+      <entity-id>@sso-entity-id@</entity-id>
       <service-provider-enabled>true</service-provider-enabled>
-      <default-url>@chips-default-url@/chips/cff</default-url>
+      <default-url>@sso-chips-default-url@</default-url>
       <service-provider-artifact-binding-enabled>true</service-provider-artifact-binding-enabled>
       <service-provider-post-binding-enabled>true</service-provider-post-binding-enabled>
       <service-provider-preferred-binding>HTTP/POST</service-provider-preferred-binding>
@@ -389,10 +389,10 @@
     </jta-migratable-target>
     <weblogic-plugin-enabled>true</weblogic-plugin-enabled>
     <single-sign-on-services>
-      <published-site-url>@published-site-url@/saml2</published-site-url>
-      <entity-id>azure-sso-saml2-wlserver4</entity-id>
+      <published-site-url>@sso-published-site-url@</published-site-url>
+      <entity-id>@sso-entity-id@</entity-id>
       <service-provider-enabled>true</service-provider-enabled>
-      <default-url>@chips-default-url@/chips/cff</default-url>
+      <default-url>@sso-chips-default-url@</default-url>
       <service-provider-artifact-binding-enabled>true</service-provider-artifact-binding-enabled>
       <service-provider-post-binding-enabled>true</service-provider-post-binding-enabled>
       <service-provider-preferred-binding>HTTP/POST</service-provider-preferred-binding>
@@ -433,7 +433,7 @@
     <target>wlcluster</target>
     <module-type>ear</module-type>
     <source-path>upload/weblogic/chips.ear</source-path>
-    <security-dd-model>CustomRolesAndPolicies</security-dd-model>
+    <security-dd-model>DDOnly</security-dd-model>
     <staging-mode>nostage</staging-mode>
     <plan-staging-mode xsi:nil="true"></plan-staging-mode>
     <cache-in-app-directory>false</cache-in-app-directory>

--- a/container-scripts/export-saml2-as-ldif.py
+++ b/container-scripts/export-saml2-as-ldif.py
@@ -1,3 +1,14 @@
+# This script is intended to be run manually, after IDP metadata has been manually imported
+# into the Weblogic security realm.  The script exports all data, in LDIF format, 
+# from the SAML2 Identity Assertion Provider named "SAML_IA".
+# The output will be placed in /var/tmp/SAML_IA.ldif
+# That LDIF file can then be used to provide initial realm data when the domain is started, by
+# adding the data to a file bind mounted into the wladmin container as 
+# /apps/oracle/chipsdomain/security/SAML2IdentityAsserterInit.ldift
+#
+# The script can be run inside the wladmin container, as the weblogic user, with:
+# ${ORACLE_HOME}/oracle_common/common/bin/wlst.sh -skipWLSModuleScanning ${ORACLE_HOME}/container-scripts/export-saml2-as-ldif.py
+
 # Load environment variables
 domain_name = os.environ.get("DOMAIN_NAME", "wldomain")
 admin_name = os.environ.get("ADMIN_NAME", "wladmin")

--- a/container-scripts/export-saml2-as-ldif.py
+++ b/container-scripts/export-saml2-as-ldif.py
@@ -1,0 +1,17 @@
+# Load environment variables
+domain_name = os.environ.get("DOMAIN_NAME", "wldomain")
+admin_name = os.environ.get("ADMIN_NAME", "wladmin")
+admin_pass = os.environ.get("ADMIN_PASSWORD")
+
+# Connect to the RUNNING admin server
+connect('weblogic', admin_pass, 't3://' + admin_name + ':7001')
+
+# Change location to the SAML2 Identity Assertion Provider path 
+cd ('SecurityConfiguration/' + domain_name + '/Realms/myrealm/AuthenticationProviders/SAML_IA')
+
+# Export all data as LDIF format, so that it can be imported as default data later on
+cmo.exportData('LDIF Template', '/var/tmp/SAML_IA.ldif', Properties())
+
+# Exit WLST
+# =========
+exit()

--- a/container-scripts/startAdmin.sh
+++ b/container-scripts/startAdmin.sh
@@ -34,6 +34,11 @@ sed -i "s/@start-args@/${START_ARGS}/g" config.xml
 sed -i "s/@t3-host-fqdn@/${T3_HOST_FQDN}/g" config.xml
 sed -i "s/@t3-host-port-prefix@/${T3_HOST_PORT_PREFIX}/g" config.xml
 
+# Set the Single Sign On configuration
+sed -i "s/@sso-published-site-url@/${SSO_PUBLISHED_SITE_URL}/g" config.xml
+sed -i "s/@sso-entity-id@/${SSO_ENTITY_ID}/g" config.xml
+sed -i "s/@sso-chips-default-url@/${SSO_CHIPS_DEFAULT_URL}/g" config.xml
+
 # Update the domain credentials to those provided by env var
 ${ORACLE_HOME}/oracle_common/common/bin/wlst.sh -skipWLSModuleScanning ${ORACLE_HOME}/container-scripts/set-credentials.py
 


### PR DESCRIPTION
Add the configuration to allow use of SSO in CHIPS:

- Adds configuration to config.xml for: 
  - the SAML identity asserter and authentication provider for the realm
  - the SSO/Federation services configuration to each managed server (ie. wlserver1 - 4) using placeholders for some values
- Adds the xalan.jar to the class path for the managed servers (required for SAML2 functionality).  This is the same 2.7.0 version used in the CHIPS application already.
- Updates the startAdmin.sh script to fill in the placeholders using environment variables (see readme for further info)
  - `SSO_PUBLISHED_SITE_URL`
  - `SSO_ENTITY_ID`
  - `SSO_CHIPS_DEFAULT_URL`
  
 This new configuration does not affect the usual operation of CHIPS, as it will only apply to a specific URI path that is being added to the CHIPS java code.  You can still log in using a username/password as before with it in place.

Resolves:
https://companieshouse.atlassian.net/browse/SUP-1129