### PR TITLE
SUP-1169: Retain AppD java agent jar external-services folder

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -81,7 +81,6 @@ RUN cd ${DOMAIN_NAME}/upload && \
 COPY --chown=weblogic:weblogic AppServerAgent-1.8-*.zip /opt/appdynamics/AppServerAgent.zip    
 RUN if [ -f /opt/appdynamics/AppServerAgent.zip ]; then \
       unzip /opt/appdynamics/AppServerAgent.zip -d /opt/appdynamics/AppServerAgent/  && \
-      rm -rf /opt/appdynamics/AppServerAgent/ver*/external-services/ && \
       rm /opt/appdynamics/AppServerAgent.zip; \
     fi
 


### PR DESCRIPTION
Need AppD java agent jar supplied OTB with external-services folder. We need the argentoDynamicService subfolder to support AppD SecureApp features. For example, without it the Vulnerabilities feature will not work. 

We only removed before to suppress NetVizAgentRequest errors in agent logs. 

SUP-1169