### PR TITLE
SUP-1177 Set the shrink frequency to 0 secs

### DIFF
--- a/config/jdbc/chipsDS-jdbc.xml
+++ b/config/jdbc/chipsDS-jdbc.xml
@@ -21,7 +21,7 @@
     <initial-capacity>1</initial-capacity>
     <max-capacity>25</max-capacity>
     <capacity-increment>1</capacity-increment>
-    <shrink-frequency-seconds>300</shrink-frequency-seconds>
+    <shrink-frequency-seconds>0</shrink-frequency-seconds>
     <highest-num-waiters>2147483647</highest-num-waiters>
     <connection-creation-retry-frequency-seconds>0</connection-creation-retry-frequency-seconds>
     <connection-reserve-timeout-seconds>10</connection-reserve-timeout-seconds>


### PR DESCRIPTION
Updates the shrink frequency setting to back to 0 to revert the workaround carried out as part of [CM-1120](https://companieshouse.atlassian.net/browse/CM-1120).

Resolves: 

https://companieshouse.atlassian.net/browse/SUP-1177

[CM-1120]: https://companieshouse.atlassian.net/browse/CM-1120?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ