### PR TITLE
SUP-1274 Refer version 1.5.9 of ch-weblogic WebLogic July 2024 patch changes

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM 300288021642.dkr.ecr.eu-west-2.amazonaws.com/ch-weblogic:1.5.8
+FROM 300288021642.dkr.ecr.eu-west-2.amazonaws.com/ch-weblogic:1.5.9
 
 # IMPORTANT - the default admin password should be supplied as a build arg
 # e.g. --build-arg ADMIN_PASSWORD=notsecure123.  This password will be visible in the image


### PR DESCRIPTION
SUP-1274  - Refer version 1.5.9 of ch-weblogic to bring WebLogic July 2024 patch changes
