### PR TITLE
Override the v$session.machine property

### DIFF
--- a/container-scripts/set-jdbc-details.py
+++ b/container-scripts/set-jdbc-details.py
@@ -7,11 +7,13 @@ db_url_chipsDS  = os.environ.get("DB_URL_CHIPSDS", 'db_url_chipsds_missing')
 db_user_staffDS  = os.environ.get("DB_USER_STAFFDS", 'db_user_staffds_missing')
 db_password_staffDS  = os.environ.get("DB_PASSWORD_STAFFDS", 'db_password_staffds_missing')
 db_url_staffDS  = os.environ.get("DB_URL_STAFFDS", 'db_url_staffds_missing')
+db_client_machine_override = os.environ.get("APP_INSTANCE_NAME", 'APP_INSTANCE_NAME missing') + '-${servername}'
 
 print('domain_name : [%s]' % domain_name);
 print('domain_path : [%s]' % domain_path);
 print('db_url_chipsDS : [%s]' % db_url_chipsDS);
 print('db_url_staffDS : [%s]' % db_url_staffDS);
+print('db_client_machine_override : [%s]' % db_client_machine_override);
 
 # Open the domain
 # ======================
@@ -37,6 +39,36 @@ cmo.setUrl(db_url_staffDS)
 
 cd('/JDBCSystemResource/staffwareDs/JdbcResource/staffwareDs/JDBCDriverParams/NO_NAME_0/Properties/NO_NAME_0/Property/user')
 cmo.setValue(db_user_staffDS)
+
+## Override the client machine property to include the instance name
+errorMessage='This error is ok. v$session.machine property already present - will update it.'
+# chipsDS
+cd('/JDBCSystemResource/chipsDS/JdbcResource/chipsDS/JDBCDriverParams/NO_NAME_0/Properties/NO_NAME_0')
+try:
+  create('v$session.machine','Property')
+except:
+  print errorMessage
+
+cd('Property/v$session.machine')
+set('SysPropValue', db_client_machine_override)
+# staffwareDs
+cd('/JDBCSystemResource/staffwareDs/JdbcResource/staffwareDs/JDBCDriverParams/NO_NAME_0/Properties/NO_NAME_0')
+try:
+  create('v$session.machine','Property')
+except:
+  print errorMessage
+
+cd('Property/v$session.machine')
+set('SysPropValue', db_client_machine_override)
+# chipsBulkDS
+cd('/JDBCSystemResource/chipsBulkDS/JdbcResource/chipsBulkDS/JDBCDriverParams/NO_NAME_0/Properties/NO_NAME_0')
+try:
+  create('v$session.machine','Property')
+except:
+  print errorMessage
+
+cd('Property/v$session.machine')
+set('SysPropValue', db_client_machine_override)
 
 # Write Domain
 # ============

--- a/container-scripts/set-jdbc-details.py
+++ b/container-scripts/set-jdbc-details.py
@@ -42,6 +42,7 @@ cmo.setValue(db_user_staffDS)
 
 ## Override the client machine property to include the instance name
 errorMessage='This error is ok. v$session.machine property already present - will update it.'
+
 # chipsDS
 cd('/JDBCSystemResource/chipsDS/JdbcResource/chipsDS/JDBCDriverParams/NO_NAME_0/Properties/NO_NAME_0')
 try:
@@ -51,6 +52,7 @@ except:
 
 cd('Property/v$session.machine')
 set('SysPropValue', db_client_machine_override)
+
 # staffwareDs
 cd('/JDBCSystemResource/staffwareDs/JdbcResource/staffwareDs/JDBCDriverParams/NO_NAME_0/Properties/NO_NAME_0')
 try:
@@ -60,6 +62,7 @@ except:
 
 cd('Property/v$session.machine')
 set('SysPropValue', db_client_machine_override)
+
 # chipsBulkDS
 cd('/JDBCSystemResource/chipsBulkDS/JdbcResource/chipsBulkDS/JDBCDriverParams/NO_NAME_0/Properties/NO_NAME_0')
 try:


### PR DESCRIPTION
Changes the jdbc client v$session.machine property so that instead of being just `wlserver1`, or `wlserver2` etc, it is now `waldorf-wlserver1` or `waldorf-wlserver2` etc, based on the `APP_INSTANCE_NAME` env var.   For staging/live environments it will be `chips-users-rest0-wlserver1` etc.

This allows support teams to see where connections are being established from when monitoring the CHIPS databases.

Resolves:
https://companieshouse.atlassian.net/browse/CHP-226