### PR TITLE
Increase complete-message-timeout to 300 from default of 60 secs

### DIFF
--- a/config/config.xml
+++ b/config/config.xml
@@ -128,6 +128,7 @@
   <server>
     <name>wlserver1</name>
     <max-message-size>100000000</max-message-size>
+    <complete-message-timeout>300</complete-message-timeout>
     <ssl>
       <hostname-verifier xsi:nil="true"></hostname-verifier>
       <hostname-verification-ignored>true</hostname-verification-ignored>
@@ -201,6 +202,7 @@
   <server>
     <name>wlserver2</name>
     <max-message-size>100000000</max-message-size>
+    <complete-message-timeout>300</complete-message-timeout>
     <ssl>
       <hostname-verifier xsi:nil="true"></hostname-verifier>
       <hostname-verification-ignored>true</hostname-verification-ignored>
@@ -274,6 +276,7 @@
   <server>
     <name>wlserver3</name>
     <max-message-size>100000000</max-message-size>
+    <complete-message-timeout>300</complete-message-timeout>
     <ssl>
       <hostname-verifier xsi:nil="true"></hostname-verifier>
       <hostname-verification-ignored>true</hostname-verification-ignored>
@@ -347,6 +350,7 @@
   <server>
     <name>wlserver4</name>
     <max-message-size>100000000</max-message-size>
+    <complete-message-timeout>300</complete-message-timeout>
     <ssl>
       <hostname-verifier xsi:nil="true"></hostname-verifier>
       <hostname-verification-ignored>true</hostname-verification-ignored>


### PR DESCRIPTION
Adds a new config element complete-message-timeout with a value of 300 (seconds), in order to override the default of 60.   

This allows downloads of large zips in query handling, over a slower connection such as via VPN.  Without the increased timeout, the downloads are getting cancelled by Weblogic if they take more 60 seconds.

Resolves:
https://companieshouse.atlassian.net/browse/AOAF-556