### PR TITLE
Update ARTIFACTORY_BASE_URL and link FOP fonts to /usr/share/fonts

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -55,7 +55,7 @@ USER root
 RUN cd ${JAVA_HOME}/jre/lib && \
     curl ${ARTIFACTORY_BASE_URL}/uk/gov/companieshouse/chips-fop-fonts/1.0.1/chips-fop-fonts-1.0.1.tar -o chips-fop-fonts.tar && \
     tar -xvf chips-fop-fonts.tar && rm chips-fop-fonts.tar && \
-    ln -s fonts /usr/share/fonts && \
+    ln -s ${JAVA_HOME}/jre/lib/fonts /usr/share/fonts && \
     mkdir -p endorsed && cd endorsed && curl ${ARTIFACTORY_BASE_URL}/xalan/xalan/2.7.0/xalan-2.7.0.jar -o xalan-2.7.0.jar
 
 # Copy across csi web app and correct permissions of upload folder

--- a/Dockerfile
+++ b/Dockerfile
@@ -49,15 +49,14 @@ RUN $ORACLE_HOME/oracle_common/common/bin/wlst.sh -skipWLSModuleScanning contain
 RUN sed -i 's/umask 027/umask 022/' ${DOMAIN_NAME}/bin/startWebLogic.sh && \
     sed -i 's/umask 027/umask 022/' ${ORACLE_HOME}/wlserver/server/bin/startNodeManager.sh
 
-# Download endorsed libs from artifactory and install into JRE
+# Download fonts and endorsed libs from artifactory and install into JRE and OS
+# OS font location is used by PDFBox and JRE location by FOP
 USER root
 RUN cd ${JAVA_HOME}/jre/lib && \
-    mkdir -p endorsed && cd endorsed && curl ${ARTIFACTORY_BASE_URL}/xalan/xalan/2.7.0/xalan-2.7.0.jar -o xalan-2.7.0.jar
-
-# Download FOP/PDFBox fonts from artifactory and install into OS
-RUN mkdir -p /usr/share/fonts && cd /usr/share && \
     curl ${ARTIFACTORY_BASE_URL}/uk/gov/companieshouse/chips-fop-fonts/1.0.1/chips-fop-fonts-1.0.1.tar -o chips-fop-fonts.tar && \
-    tar -xvf chips-fop-fonts.tar && rm chips-fop-fonts.tar
+    tar -xvf chips-fop-fonts.tar && rm chips-fop-fonts.tar && \
+    ln -s fonts /usr/share/fonts && \
+    mkdir -p endorsed && cd endorsed && curl ${ARTIFACTORY_BASE_URL}/xalan/xalan/2.7.0/xalan-2.7.0.jar -o xalan-2.7.0.jar
 
 # Copy across csi web app and correct permissions of upload folder
 COPY --chown=weblogic:weblogic csi ${DOMAIN_NAME}/upload/csi/

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,7 @@ ARG ADMIN_PASSWORD
 ENV ORACLE_HOME=/apps/oracle \
     DOMAIN_NAME=chipsdomain \
     ADMIN_NAME=wladmin \
-    ARTIFACTORY_BASE_URL=http://repository.aws.chdev.org:8081/artifactory
+    ARTIFACTORY_BASE_URL=https://artifactory.companieshouse.gov.uk/artifactory/virtual-release
 
 WORKDIR $ORACLE_HOME
 
@@ -26,19 +26,19 @@ COPY --chown=weblogic:weblogic chipsconfig ${DOMAIN_NAME}/chipsconfig/
 
 # Download libs and ixbrl fonts from artifactory
 RUN cd ${DOMAIN_NAME}/chipsconfig && \
-    curl ${ARTIFACTORY_BASE_URL}/libs-release/antlr/antlr/2.7.6/antlr-2.7.6.jar -o antlr-2.7.6.jar && \
-    curl ${ARTIFACTORY_BASE_URL}/libs-release/org/xhtmlrenderer/core-renderer/R5pre1patched/core-renderer-R5pre1patched.jar -o core-renderer.jar && \
-    curl ${ARTIFACTORY_BASE_URL}/libs-release/log4j/log4j/1.2.14/log4j-1.2.14.jar -o log4j.jar && \
-    curl ${ARTIFACTORY_BASE_URL}/local-ch-release/oracle/AQ/unknown/AQ-unknown.jar -o aqapi12.jar && \
-    curl ${ARTIFACTORY_BASE_URL}/libs-release/com/lowagie/itext/2.0.8/itext-2.0.8.jar -o itext-2.0.8.jar && \
-    curl ${ARTIFACTORY_BASE_URL}/libs-release/com/staffware/ssoRMI/11.4.1/ssoRMI-11.4.1.jar -o ssoRMI.jar && \
-    curl ${ARTIFACTORY_BASE_URL}/libs-release/org/jdom/jdom/1.1/jdom-1.1.jar -o jdom.jar && \
-    curl ${ARTIFACTORY_BASE_URL}/local-ch-release/uk/gov/companieshouse/jmstool/1.2.0/jmstool-1.2.0.jar -o jmstool.jar && \
-    curl ${ARTIFACTORY_BASE_URL}/local-ch-release/uk/gov/companieshouse/chips_common/0.0.0-alpha1/chips_common-0.0.0-alpha1.jar -o chips-common.jar && \
-    curl ${ARTIFACTORY_BASE_URL}/libs-release/uk/gov/companieshouse/weblogic-tux-hostname-patch/1.0.0/weblogic-tux-hostname-patch-1.0.0.jar -o weblogic-tux-hostname-patch-1.0.0.jar && \
-    curl ${ARTIFACTORY_BASE_URL}/libs-release/xalan/xalan/2.7.0/xalan-2.7.0.jar -o xalan.jar && \
+    curl ${ARTIFACTORY_BASE_URL}/antlr/antlr/2.7.6/antlr-2.7.6.jar -o antlr-2.7.6.jar && \
+    curl ${ARTIFACTORY_BASE_URL}/org/xhtmlrenderer/core-renderer/R5pre1patched/core-renderer-R5pre1patched.jar -o core-renderer.jar && \
+    curl ${ARTIFACTORY_BASE_URL}/log4j/log4j/1.2.14/log4j-1.2.14.jar -o log4j.jar && \
+    curl ${ARTIFACTORY_BASE_URL}/oracle/AQ/unknown/AQ-unknown.jar -o aqapi12.jar && \
+    curl ${ARTIFACTORY_BASE_URL}/com/lowagie/itext/2.0.8/itext-2.0.8.jar -o itext-2.0.8.jar && \
+    curl ${ARTIFACTORY_BASE_URL}/com/staffware/ssoRMI/11.4.1/ssoRMI-11.4.1.jar -o ssoRMI.jar && \
+    curl ${ARTIFACTORY_BASE_URL}/org/jdom/jdom/1.1/jdom-1.1.jar -o jdom.jar && \
+    curl ${ARTIFACTORY_BASE_URL}/uk/gov/companieshouse/jmstool/1.2.0/jmstool-1.2.0.jar -o jmstool.jar && \
+    curl ${ARTIFACTORY_BASE_URL}/uk/gov/companieshouse/chips_common/0.0.0-alpha1/chips_common-0.0.0-alpha1.jar -o chips-common.jar && \
+    curl ${ARTIFACTORY_BASE_URL}/uk/gov/companieshouse/weblogic-tux-hostname-patch/1.0.0/weblogic-tux-hostname-patch-1.0.0.jar -o weblogic-tux-hostname-patch-1.0.0.jar && \
+    curl ${ARTIFACTORY_BASE_URL}/xalan/xalan/2.7.0/xalan-2.7.0.jar -o xalan.jar && \
     cd .. && \
-    curl ${ARTIFACTORY_BASE_URL}/local-ch-release/uk/gov/companieshouse/chips-ixbrl-fonts/1.0.0/chips-ixbrl-fonts-1.0.0.tar -o chips-ixbrl-fonts.tar && \
+    curl ${ARTIFACTORY_BASE_URL}/uk/gov/companieshouse/chips-ixbrl-fonts/1.0.0/chips-ixbrl-fonts-1.0.0.tar -o chips-ixbrl-fonts.tar && \
     tar -xvf chips-ixbrl-fonts.tar && rm chips-ixbrl-fonts.tar
 
 # Set the credentials in the custom config.xml
@@ -49,12 +49,15 @@ RUN $ORACLE_HOME/oracle_common/common/bin/wlst.sh -skipWLSModuleScanning contain
 RUN sed -i 's/umask 027/umask 022/' ${DOMAIN_NAME}/bin/startWebLogic.sh && \
     sed -i 's/umask 027/umask 022/' ${ORACLE_HOME}/wlserver/server/bin/startNodeManager.sh
 
-# Download fop fonts and endorsed libs from artifactory and install into JRE
+# Download endorsed libs from artifactory and install into JRE
 USER root
 RUN cd ${JAVA_HOME}/jre/lib && \
-    curl ${ARTIFACTORY_BASE_URL}/local-ch-release/uk/gov/companieshouse/chips-fop-fonts/1.0.1/chips-fop-fonts-1.0.1.tar -o chips-fop-fonts.tar && \
-    tar -xvf chips-fop-fonts.tar && rm chips-fop-fonts.tar && \
-    mkdir -p endorsed && cd endorsed && curl ${ARTIFACTORY_BASE_URL}/libs-release/xalan/xalan/2.7.0/xalan-2.7.0.jar -o xalan-2.7.0.jar
+    mkdir -p endorsed && cd endorsed && curl ${ARTIFACTORY_BASE_URL}/xalan/xalan/2.7.0/xalan-2.7.0.jar -o xalan-2.7.0.jar
+
+# Download FOP/PDFBox fonts from artifactory and install into OS
+RUN mkdir -p /usr/share/fonts && cd /usr/share && \
+    curl ${ARTIFACTORY_BASE_URL}/uk/gov/companieshouse/chips-fop-fonts/1.0.1/chips-fop-fonts-1.0.1.tar -o chips-fop-fonts.tar && \
+    tar -xvf chips-fop-fonts.tar && rm chips-fop-fonts.tar
 
 # Copy across csi web app and correct permissions of upload folder
 COPY --chown=weblogic:weblogic csi ${DOMAIN_NAME}/upload/csi/


### PR DESCRIPTION
Adds a soft link to the FOP fonts in the JRE, so that they are available to the OS (hence PDFBox) as well as FOP.

Additionally, updates the ARTIFACTORY_BASE_URL to reflect the availability of the new artifactory instance.

Resolves:
https://companieshouse.atlassian.net/browse/CHP-274