### PR TITLE
CHP-269: Added new logger for production/staging

### DIFF
--- a/chipsconfig/unixlog4j.xml
+++ b/chipsconfig/unixlog4j.xml
@@ -111,20 +111,25 @@
     <appender-ref ref="ConsoleAppender"/>
   </logger>
 
-<logger name="uk.gov.ch.imagesender.client.ImageToS3StoreSender" additivity="false">
-  <level value="INFO"/>
-  <appender-ref ref="ConsoleAppender"/>
-</logger>
+  <logger name="uk.gov.ch.imagesender.client.ImageToS3StoreSender" additivity="false">
+    <level value="INFO"/>
+    <appender-ref ref="ConsoleAppender"/>
+  </logger>
 
-<logger name="uk.gov.ch.imagesender.dao.impl.TemporaryImageStoreFileSystemDaoImpl" additivity="false">
-  <level value="DEBUG"/>
-  <appender-ref ref="ConsoleAppender"/>
-</logger>
+  <logger name="uk.gov.ch.imagesender.dao.impl.TemporaryImageStoreFileSystemDaoImpl" additivity="false">
+    <level value="DEBUG"/>
+    <appender-ref ref="ConsoleAppender"/>
+  </logger>
 
-<logger name="uk.gov.ch.cap.server.image.RemoteElectronicFOPImage" additivity="false">
-  <level value="INFO"/>
-  <appender-ref ref="ConsoleAppender"/>
-</logger>
+  <logger name="uk.gov.ch.cap.server.image.RemoteElectronicFOPImage" additivity="false">
+    <level value="INFO"/>
+    <appender-ref ref="ConsoleAppender"/>
+  </logger>
+
+  <logger name="uk.gov.ch.chips.server.workflow.ProcessWorkObjectRetry" additivity="false">
+    <level value="INFO"/>
+    <appender-ref ref="ConsoleAppender"/>
+  </logger>
 
   <!-- Root logger -->
   <root>


### PR DESCRIPTION
Added uk.gov.ch.chips.server.workflow.ProcessWorkObjectRetry logger at info level.

Info level for this class only results in logging of retry attempts. This is an exceptional condition so should be rare but, when it does happen, we want a record of the retry logic being invoked.

Minor formatting tidy up for some existing loggers.

CHP-269