### PR TITLE
Disable auth cookie to avoid intermittent 401/403 issues

### DIFF
--- a/config/config.xml
+++ b/config/config.xml
@@ -607,6 +607,9 @@
     <user-preferred-server>wlserver4</user-preferred-server>
     <cluster>wlcluster</cluster>
   </migratable-target>
+  <web-app-container>
+    <auth-cookie-enabled>false</auth-cookie-enabled>
+  </web-app-container>
   <jmx>
     <compatibility-m-bean-server-enabled>true</compatibility-m-bean-server-enabled>
     <management-ejb-enabled>true</management-ejb-enabled>


### PR DESCRIPTION
There is a live issue, where users sometimes get a 401 or 403 when logging into CHIPS and the error persists until they close down their web browser.  

This appears to be due to some form of corruption or mixup between the `_WL_AUTHCOOKIE_JSESSIONID` cookie and the `JSESSIONID` cookie values, such that Weblogic decides they are not authorised, and continues to deny access while the invalid `_WL_AUTHCOOKIE_JSESSIONID` cookie is sent by the browser.
The `_WL_AUTHCOOKIE_JSESSIONID` is not required and is used to handle situations where there are requests being made without SSL.  All CHIPS user access is under SSL at all times, so it is safe to disable the checking and issuing of that cookie by setting auth-cookie-enabled=false in the Weblogic domain configuration.

Resolves:
https://companieshouse.atlassian.net/browse/CHP-1221