### PR TITLE
Remove Active Directory authentication provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,12 +33,6 @@ In order to use the image, a number of environment properties need to be defined
 |START_ARGS|Any startup JVM arguments that should be used when starting the managed server|-Dmyarg=true -Dmyotherarg=false
 |USER_MEM_ARGS|JVM arguments for setting the GC and memory settings for the managed server.  These will be included at the start of the arguments to the JVM|-XX:+UseG1GC -verbose:gc -XX:+PrintGCDetails -XX:+PrintGCDateStamps -Xms712m -Xmx712m
 |ADMIN_MEM_ARGS|JVM arguments for setting the GC and memory settings for the admin server.  These will be included at the start of the arguments to the JVM|-Djava.security.egd=file:/dev/./urandom -Xms32m -Xmx512m
-|AD_HOST|The hostname or ip of the Active Directory server against which to authenticate users|ldap99.domain.ch
-|AD_PORT|The port to use for a SSL connection|636
-|AD_PRINCIPAL|The user in AD for connecting in order to authenticate other user logins|CN=myldpauser, OU=AD Groups, OU=MySection, OU=MyOrg, DC=MyDepartment, DC=local
-|AD_CREDENTIAL|The password of the user in AD for connecting in order to authenticate other user logins|password
-|AD_USER_BASE_DN|The base location under which users can be found via a subtree search|OU=MySection, OU=MyOrg, DC=MyDepartment, DC=local
-|AD_GROUP_BASE_DN|The base location under which groups can be found via a subtree search|OU=MySection, OU=MyOrg, DC=MyDepartment, DC=local
 |AUTO_START_NODES|A list of managed server names to auto start when the container is launched|wlserver1,wlserver2,wlserver3,wlserver4
 |WLADMIN_AWAIT_TIMEOUT|The number of seconds to wait for the wladmin server to start up, before abandoning the auto start of a managed server. Optional, as there is a default of 180 secs if this is not set.|240
 |TZ|The timezone to use when running WebLogic|Europe/London

--- a/config/config.xml
+++ b/config/config.xml
@@ -18,26 +18,6 @@
         <sec:active-type>AuthenticatedUser</sec:active-type>
         <sec:active-type>weblogic-jwt-token</sec:active-type>
       </sec:authentication-provider>
-      <sec:authentication-provider xsi:type="wls:active-directory-authenticatorType">
-        <sec:name>AD_LDAP</sec:name>
-        <sec:control-flag>OPTIONAL</sec:control-flag>
-        <wls:host></wls:host>
-        <wls:port></wls:port>
-        <wls:ssl-enabled>true</wls:ssl-enabled>
-        <wls:user-name-attribute>sAMAccountName</wls:user-name-attribute>
-        <wls:principal></wls:principal>
-        <wls:user-base-dn></wls:user-base-dn>
-        <wls:cache-enabled>false</wls:cache-enabled>
-        <wls:user-from-name-filter>(&amp;(sAMAccountName=%u)(objectclass=user))</wls:user-from-name-filter>
-        <wls:group-base-dn></wls:group-base-dn>
-        <wls:group-search-scope>onelevel</wls:group-search-scope>
-        <wls:connect-timeout>5</wls:connect-timeout>
-        <wls:group-from-name-filter>(&amp;(cn=%g)(objectclass=group))</wls:group-from-name-filter>
-        <wls:static-group-object-class>group</wls:static-group-object-class>
-        <wls:static-group-name-attribute>cn</wls:static-group-name-attribute>
-        <wls:static-group-dns-from-member-dn-filter>(&amp;(member=%M)(objectclass=group))</wls:static-group-dns-from-member-dn-filter>
-        <wls:group-membership-searching>off</wls:group-membership-searching>
-      </sec:authentication-provider>
       <sec:authentication-provider xmlns:sam="http://xmlns.oracle.com/weblogic/security/saml2" xsi:type="sam:saml2-identity-asserterType">
         <sec:name>SAML_IA</sec:name>
       </sec:authentication-provider>

--- a/container-scripts/set-credentials.py
+++ b/container-scripts/set-credentials.py
@@ -5,12 +5,6 @@ admin_pass   = os.environ.get("ADMIN_PASSWORD")
 domain_path  = '/apps/oracle/%s' % domain_name
 domain_credential  = os.environ.get("DOMAIN_CREDENTIAL", "domain_credential")
 ldap_credential  = os.environ.get("LDAP_CREDENTIAL", "ldap_credential")
-ad_host  = os.environ.get("AD_HOST", "ad_host")
-ad_port  = eval(os.environ.get("AD_PORT", "389"))
-ad_principal  = os.environ.get("AD_PRINCIPAL", "ad_principal")
-ad_credential  = os.environ.get("AD_CREDENTIAL", "ad_credential")
-ad_user_base_dn  = os.environ.get("AD_USER_BASE_DN", "ad_user_base_dn")
-ad_group_base_dn  = os.environ.get("AD_GROUP_BASE_DN", "ad_group_base_dn")
 
 print('domain_name : [%s]' % domain_name);
 print('admin_name : [%s]' % admin_name);
@@ -27,15 +21,6 @@ set('CredentialEncrypted', encrypt(domain_credential, domain_path))
 # Set the Node Manager user name and password 
 set('NodeManagerUsername', 'weblogic')
 set('NodeManagerPasswordEncrypted', admin_pass)
-
-# Active Directory connection details and credentials
-cd('/SecurityConfiguration/' + domain_name + '/Realms/myrealm/AuthenticationProviders/AD_LDAP')
-set('GroupBaseDN', ad_group_base_dn)
-set('UserBaseDN', ad_user_base_dn)
-set('Host', ad_host)
-set('Port', ad_port)
-set('Principal', ad_principal)
-set('CredentialEncrypted', encrypt(ad_credential, domain_path))
 
 # Set the Embedded LDAP server credential
 cd('/EmbeddedLDAP/'  + domain_name)


### PR DESCRIPTION
Remove the LDAP/AD authentication provide configuration, so that only SSO or an internal realm user can be used to log into CHIPS.

Note that on dev environments (local and E2Es) SSO is not normally configured, therefore an internal realm user will be required, which is typically what is used on those environments anyway.

Resolves:
https://companieshouse.atlassian.net/browse/CHP-1344